### PR TITLE
Add Flask-based Industrial Physics quiz experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv/
+instance/
+.pytest_cache/
+.coverage
+htmlcov/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+ENV PORT=8000
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Industrial Physics Quiz
+
+This project implements a small Flask web application that delivers an Industrial Physics readiness quiz. The quiz is dynamically driven by the JSON configuration stored at `data/quiz_schema.json` and produces personalized feedback based on trait scores.
+
+## Features
+
+- JSON-driven quiz configuration with validation on load
+- Dynamic question rendering with optional within-type shuffling
+- Client-side progress indicator and persisted selections on validation errors
+- Trait scoring with caps, overall Industrial Physics fit score, and tier mapping
+- Tailored feedback, highlights, and recommended next steps
+- Simple responsive UI with result visualizations
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+
+2. **Run the development server**
+
+   ```bash
+   python app.py
+   ```
+
+   The application listens on `http://127.0.0.1:8000` by default.
+
+3. **Take the quiz**
+
+   - Visit `/` for the introduction
+   - Complete the quiz at `/quiz`
+   - Review your personalized results at `/result`
+
+## Project Structure
+
+```
+app.py               # Flask application entrypoint
+quiz/                # Quiz domain modules (models, loader, scoring, forms, rendering, utils)
+templates/           # Jinja2 templates for the UI
+static/              # Stylesheet and client-side script
+requirements.txt     # Python dependencies
+```
+
+## Configuration
+
+Quiz content, scoring, and UI toggles are controlled via `data/quiz_schema.json`. Update this file to change questions, trait weights, or feedback messaging. The loader module performs validation to ensure trait codes and scoring data remain consistent.
+
+## Environment Variables
+
+- `APP_SECRET` — Overrides the default Flask secret key used for session management.
+- `PORT` — Port number used when running `app.py` directly (defaults to `8000`).
+
+## Testing Notes
+
+The application relies on Flask's built-in development server. Manual validation steps are outlined in the project charter and can be followed by interacting with the running web app.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,141 @@
+"""Flask entrypoint for the Industrial Physics quiz application."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from flask import (
+    Flask,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from quiz.forms import AnswerValidationError, parse_answers
+from quiz.loader import QuizConfigError, load_quiz_config
+from quiz.models import QuizConfig
+from quiz.rendering import order_questions, progress_context
+from quiz.scoring import (
+    apply_caps,
+    compute_fit_score,
+    compute_trait_scores,
+    compose_feedback,
+    map_threshold,
+)
+from quiz.utils import normalize_scores, trait_code_to_name
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_DIR = BASE_DIR / "data"
+QUIZ_SCHEMA_PATH = DATA_DIR / "quiz_schema.json"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+LOGGER = logging.getLogger(__name__)
+
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "templates"),
+    static_folder=str(BASE_DIR / "static"),
+)
+app.secret_key = os.getenv("APP_SECRET", "change-me")
+
+
+def _load_config() -> QuizConfig:
+    LOGGER.info("Loading quiz configuration for request")
+    return load_quiz_config(QUIZ_SCHEMA_PATH)
+
+
+@app.errorhandler(QuizConfigError)
+def handle_config_error(error: QuizConfigError):  # type: ignore[override]
+    LOGGER.exception("Quiz configuration error: %s", error)
+    return (
+        render_template("error.html", message="Quiz temporarily unavailable."),
+        500,
+    )
+
+
+@app.route("/")
+def index():
+    LOGGER.info("Handling index route")
+    config = _load_config()
+    return render_template("index.html", config=config)
+
+
+@app.route("/quiz", methods=["GET", "POST"])
+def quiz_view():
+    LOGGER.info("Handling quiz route")
+    config = _load_config()
+    ordered_questions = order_questions(config)
+    if request.method == "POST":
+        try:
+            answers = parse_answers(config, request.form)
+        except AnswerValidationError as exc:
+            flash(str(exc), "error")
+            return render_template(
+                "quiz.html",
+                config=config,
+                questions=ordered_questions,
+                progress=progress_context(len(ordered_questions)),
+                previous_answers=request.form,
+            )
+        session["quiz_id"] = config.quiz_id
+        session["answers"] = answers
+        return redirect(url_for("result"))
+
+    previous_answers = session.get("answers") if session.get("quiz_id") == config.quiz_id else None
+    return render_template(
+        "quiz.html",
+        config=config,
+        questions=ordered_questions,
+        progress=progress_context(len(ordered_questions)),
+        previous_answers=previous_answers,
+    )
+
+
+@app.route("/result")
+def result():
+    LOGGER.info("Handling result route")
+    config = _load_config()
+    answers = session.get("answers")
+    if not answers or session.get("quiz_id") != config.quiz_id:
+        flash("Please complete the quiz first.", "error")
+        return redirect(url_for("quiz_view"))
+
+    raw_scores = compute_trait_scores(config, answers)
+    capped_scores = apply_caps(config, raw_scores)
+    normalized = normalize_scores(config, capped_scores)
+    fit_score = compute_fit_score(config, capped_scores)
+    label = map_threshold(config, fit_score)
+    feedback = compose_feedback(config, capped_scores, label)
+
+    trait_names = trait_code_to_name(config)
+    trait_display = []
+    for trait in config.traits:
+        code = trait.code
+        trait_display.append(
+            {
+                "code": code,
+                "name": trait_names.get(code, code),
+                "score": capped_scores.get(code, 0.0),
+                "normalized": normalized.get(code, 0.0),
+            }
+        )
+
+    return render_template(
+        "result.html",
+        config=config,
+        fit_score=round(fit_score, 1),
+        label=label,
+        normalized=normalized,
+        traits=trait_display,
+        feedback=feedback,
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", 8000)), debug=False)

--- a/quiz/__init__.py
+++ b/quiz/__init__.py
@@ -1,0 +1,6 @@
+"""Quiz package initialization."""
+
+from .loader import load_quiz_config
+from .models import QuizConfig
+
+__all__ = ["load_quiz_config", "QuizConfig"]

--- a/quiz/forms.py
+++ b/quiz/forms.py
@@ -1,0 +1,48 @@
+"""Form parsing helpers for the quiz application."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from werkzeug.datastructures import ImmutableMultiDict
+
+from .models import ForcedChoiceQuestion, LikertQuestion, QuizConfig, SingleChoiceQuestion
+
+
+class AnswerValidationError(ValueError):
+    """Raised when submitted answers fail validation."""
+
+
+def parse_answers(config: QuizConfig, form: ImmutableMultiDict) -> Dict[str, Any]:
+    """Validate and normalize answers submitted from the quiz form."""
+
+    answers: Dict[str, Any] = {}
+
+    for question in config.questions:
+        value = form.get(question.id)
+        if value is None or value == "":
+            raise AnswerValidationError(f"Question {question.id} is required.")
+
+        if isinstance(question, (SingleChoiceQuestion, ForcedChoiceQuestion)):
+            option_keys = {opt.key for opt in question.options}
+            if value not in option_keys:
+                raise AnswerValidationError(
+                    f"Invalid option for question {question.id}."
+                )
+            answers[question.id] = value
+        elif isinstance(question, LikertQuestion):
+            try:
+                numeric_value = int(value)
+            except ValueError as exc:
+                raise AnswerValidationError(
+                    f"Invalid response for question {question.id}."
+                ) from exc
+            if numeric_value not in question.scale:
+                raise AnswerValidationError(
+                    f"Selected value for question {question.id} is outside the allowed scale."
+                )
+            answers[question.id] = numeric_value
+        else:  # pragma: no cover - defensive branch
+            raise AnswerValidationError(f"Unsupported question type {question.type}.")
+
+    return answers

--- a/quiz/loader.py
+++ b/quiz/loader.py
@@ -1,0 +1,198 @@
+"""Utility for loading the quiz configuration from JSON."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .models import (
+    ChoiceOption,
+    FeedbackTemplates,
+    ForcedChoiceQuestion,
+    LikertQuestion,
+    QuizConfig,
+    QuestionBase,
+    QuestionType,
+    ScoringSpec,
+    SingleChoiceQuestion,
+    Trait,
+    UISettings,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+REQUIRED_TOP_LEVEL_KEYS: tuple[str, ...] = (
+    "quiz_id",
+    "title",
+    "traits",
+    "questions",
+    "scoring",
+    "feedback_templates",
+)
+
+
+class QuizConfigError(RuntimeError):
+    """Raised when the quiz configuration file fails validation."""
+
+
+def _require_keys(payload: Dict[str, Any], keys: Iterable[str]) -> None:
+    missing = [key for key in keys if key not in payload]
+    if missing:
+        raise QuizConfigError(f"Missing required keys: {', '.join(sorted(missing))}")
+
+
+def _validate_weights(trait_codes: set[str], weights: Dict[str, float], *, context: str) -> None:
+    unknown = set(weights) - trait_codes
+    if unknown:
+        raise QuizConfigError(f"Unknown trait codes {unknown} in {context}")
+
+
+def _build_choice_question(
+    base: Dict[str, Any],
+    trait_codes: set[str],
+    *,
+    forced: bool = False,
+) -> QuestionBase:
+    options: List[ChoiceOption] = []
+    seen_keys: set[str] = set()
+    for opt in base.get("options", []):
+        key = opt.get("key")
+        if key in seen_keys:
+            raise QuizConfigError(f"Duplicate option key '{key}' in question {base.get('id')}")
+        seen_keys.add(key)
+        weights = opt.get("weights", {})
+        _validate_weights(trait_codes, weights, context=f"question {base.get('id')} option {key}")
+        options.append(
+            ChoiceOption(
+                key=key,
+                label=opt.get("label", ""),
+                weights={code: float(value) for code, value in weights.items()},
+            )
+        )
+    if forced:
+        return ForcedChoiceQuestion(
+            id=base["id"],
+            type=base["type"],
+            text=base.get("text", ""),
+            options=options,
+            tags=base.get("tags"),
+        )
+    return SingleChoiceQuestion(
+        id=base["id"],
+        type=base["type"],
+        text=base.get("text", ""),
+        options=options,
+        tags=base.get("tags"),
+    )
+
+
+def _build_likert_question(base: Dict[str, Any], trait_codes: set[str]) -> LikertQuestion:
+    scale = base.get("scale", [])
+    if not scale:
+        raise QuizConfigError(f"Likert question {base.get('id')} requires a scale")
+    weights = base.get("weights_per_point", {})
+    _validate_weights(trait_codes, weights, context=f"question {base.get('id')} weights_per_point")
+    return LikertQuestion(
+        id=base["id"],
+        type=base["type"],
+        text=base.get("text", ""),
+        scale=[int(v) for v in scale],
+        labels={str(k): str(v) for k, v in base.get("labels", {}).items()},
+        weights_per_point={code: float(value) for code, value in weights.items()},
+        tags=base.get("tags"),
+    )
+
+
+def _build_question(base: Dict[str, Any], trait_codes: set[str]) -> QuestionBase:
+    q_type: QuestionType = base.get("type")
+    if q_type not in {"single_choice", "forced_choice", "likert"}:
+        raise QuizConfigError(f"Unsupported question type '{q_type}'")
+    if q_type == "likert":
+        return _build_likert_question(base, trait_codes)
+    return _build_choice_question(base, trait_codes, forced=q_type == "forced_choice")
+
+
+def load_quiz_config(path: Path) -> QuizConfig:
+    """Load and validate the quiz configuration file."""
+
+    LOGGER.info("Loading quiz configuration from %s", path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise QuizConfigError(f"Unable to read quiz configuration: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise QuizConfigError(f"Invalid JSON: {exc}") from exc
+
+    _require_keys(data, REQUIRED_TOP_LEVEL_KEYS)
+
+    traits_payload = data.get("traits", [])
+    if not traits_payload:
+        raise QuizConfigError("Quiz must define at least one trait")
+
+    traits = [Trait(code=item["code"], name=item.get("name", item["code"])) for item in traits_payload]
+    trait_codes = {trait.code for trait in traits}
+
+    questions_payload = data.get("questions", [])
+    if not questions_payload:
+        raise QuizConfigError("Quiz must contain at least one question")
+
+    seen_ids: set[str] = set()
+    questions: List[QuestionBase] = []
+    for q_payload in questions_payload:
+        q_id = q_payload.get("id")
+        if not q_id:
+            raise QuizConfigError("Question missing 'id'")
+        if q_id in seen_ids:
+            raise QuizConfigError(f"Duplicate question id '{q_id}'")
+        seen_ids.add(q_id)
+        question = _build_question(q_payload, trait_codes)
+        questions.append(question)
+
+    scoring_payload = data.get("scoring", {})
+    _require_keys(scoring_payload, ("trait_caps", "industrial_fit_weights", "thresholds", "normalization"))
+
+    trait_caps = scoring_payload.get("trait_caps", {})
+    industrial_weights = scoring_payload.get("industrial_fit_weights", {})
+    if set(trait_caps) != trait_codes:
+        raise QuizConfigError("Trait caps must be provided for all traits")
+    if set(industrial_weights) != trait_codes:
+        raise QuizConfigError("Industrial fit weights must be provided for all traits")
+
+    thresholds = scoring_payload.get("thresholds", [])
+    if not thresholds:
+        raise QuizConfigError("At least one scoring threshold is required")
+
+    feedback_payload = data.get("feedback_templates", {})
+    _require_keys(feedback_payload, ("overall", "trait_snippets", "next_steps"))
+
+    ui_payload = data.get("ui", {})
+
+    config = QuizConfig(
+        quiz_id=data["quiz_id"],
+        title=data["title"],
+        traits=traits,
+        questions=questions,
+        scoring=ScoringSpec(
+            trait_caps={code: float(value) for code, value in trait_caps.items()},
+            industrial_fit_weights={code: float(value) for code, value in industrial_weights.items()},
+            thresholds=thresholds,
+            normalization=scoring_payload.get("normalization", ""),
+        ),
+        feedback_templates=FeedbackTemplates(
+            overall={key: str(value) for key, value in feedback_payload.get("overall", {}).items()},
+            trait_snippets={key: str(value) for key, value in feedback_payload.get("trait_snippets", {}).items()},
+            next_steps=[str(step) for step in feedback_payload.get("next_steps", [])],
+        ),
+        ui=UISettings(
+            progress_bar=bool(ui_payload.get("progress_bar", False)),
+            shuffle_within_types=bool(ui_payload.get("shuffle_within_types", False)),
+            length_minutes=ui_payload.get("length_minutes"),
+            skip_logic=ui_payload.get("skip_logic"),
+            result_visuals=ui_payload.get("result_visuals"),
+        ),
+    )
+
+    LOGGER.info("Loaded quiz '%s' with %d questions", config.quiz_id, len(config.questions))
+    return config

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -1,0 +1,96 @@
+"""Dataclasses describing the quiz configuration domain model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+QuestionType = Literal["single_choice", "forced_choice", "likert"]
+
+
+@dataclass(slots=True)
+class Trait:
+    """Represents a trait measured by the quiz."""
+
+    code: str
+    name: str
+
+
+@dataclass(slots=True)
+class ChoiceOption:
+    """Represents a selectable option for choice-based questions."""
+
+    key: str
+    label: str
+    weights: Dict[str, float]
+
+
+@dataclass(slots=True)
+class QuestionBase:
+    """Base fields shared by all question types."""
+
+    id: str
+    type: QuestionType
+    text: str
+    tags: Optional[List[str]] = None
+
+
+@dataclass(slots=True)
+class SingleChoiceQuestion(QuestionBase):
+    """Single-choice question where one option is selected."""
+
+    options: List[ChoiceOption] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ForcedChoiceQuestion(QuestionBase):
+    """Forced-choice question with two contrasted options."""
+
+    options: List[ChoiceOption] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class LikertQuestion(QuestionBase):
+    """Likert scale question scored by selected point."""
+
+    scale: List[int] = field(default_factory=list)
+    labels: Dict[str, str] = field(default_factory=dict)
+    weights_per_point: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ScoringSpec:
+    trait_caps: Dict[str, float]
+    industrial_fit_weights: Dict[str, float]
+    thresholds: List[Dict[str, Any]]
+    normalization: str
+
+
+@dataclass(slots=True)
+class FeedbackTemplates:
+    overall: Dict[str, str]
+    trait_snippets: Dict[str, str]
+    next_steps: List[str]
+
+
+@dataclass(slots=True)
+class UISettings:
+    progress_bar: bool
+    shuffle_within_types: bool
+    length_minutes: Optional[int] = None
+    skip_logic: Optional[List[Dict[str, Any]]] = None
+    result_visuals: Optional[List[str]] = None
+
+
+@dataclass(slots=True)
+class QuizConfig:
+    quiz_id: str
+    title: str
+    traits: List[Trait]
+    questions: List[QuestionBase]
+    scoring: ScoringSpec
+    feedback_templates: FeedbackTemplates
+    ui: UISettings
+
+
+Question = SingleChoiceQuestion | ForcedChoiceQuestion | LikertQuestion

--- a/quiz/rendering.py
+++ b/quiz/rendering.py
@@ -1,0 +1,41 @@
+"""Helpers for rendering quiz questions in templates."""
+
+from __future__ import annotations
+
+import itertools
+import random
+from typing import List
+
+from .models import QuestionBase, QuizConfig
+
+
+def order_questions(config: QuizConfig) -> List[QuestionBase]:
+    """Return questions ordered according to UI settings."""
+
+    questions = list(config.questions)
+    if not config.ui.shuffle_within_types:
+        return questions
+
+    groups: dict[str, List[QuestionBase]] = {}
+    order: List[str] = []
+    for question in questions:
+        q_type = question.type
+        if q_type not in groups:
+            groups[q_type] = []
+            order.append(q_type)
+        groups[q_type].append(question)
+
+    rng = random.Random(config.quiz_id)
+    shuffled_groups = []
+    for q_type in order:
+        group = groups[q_type]
+        rng.shuffle(group)
+        shuffled_groups.append(group)
+
+    return list(itertools.chain.from_iterable(shuffled_groups))
+
+
+def progress_context(total_questions: int) -> dict[str, int]:
+    """Return a template context stub for progress bar rendering."""
+
+    return {"total_questions": total_questions}

--- a/quiz/scoring.py
+++ b/quiz/scoring.py
@@ -1,0 +1,123 @@
+"""Scoring utilities for the Industrial Physics quiz."""
+
+from __future__ import annotations
+
+import statistics
+from typing import Any, Dict, List
+
+from .models import ForcedChoiceQuestion, LikertQuestion, QuizConfig, SingleChoiceQuestion
+
+
+def _ensure_trait_keys(config: QuizConfig) -> List[str]:
+    return [trait.code for trait in config.traits]
+
+
+def compute_trait_scores(config: QuizConfig, answers: Dict[str, Any]) -> Dict[str, float]:
+    """Compute raw trait scores from submitted answers."""
+
+    trait_scores = {trait.code: 0.0 for trait in config.traits}
+    for question in config.questions:
+        answer = answers.get(question.id)
+        if answer is None:
+            continue
+        if isinstance(question, (SingleChoiceQuestion, ForcedChoiceQuestion)):
+            for option in question.options:
+                if option.key == answer:
+                    for code, value in option.weights.items():
+                        trait_scores[code] += float(value)
+                    break
+        elif isinstance(question, LikertQuestion):
+            if not isinstance(answer, int):
+                continue
+            for code, weight in question.weights_per_point.items():
+                trait_scores[code] += float(weight) * answer
+    return trait_scores
+
+
+def apply_caps(config: QuizConfig, raw: Dict[str, float]) -> Dict[str, float]:
+    """Apply trait caps defined in the configuration."""
+
+    capped = {}
+    for code, value in raw.items():
+        cap = config.scoring.trait_caps.get(code)
+        if cap is None:
+            cap = value
+        capped[code] = min(value, cap)
+    return capped
+
+
+def compute_fit_score(config: QuizConfig, capped: Dict[str, float]) -> float:
+    """Compute the overall Industrial Physics fit score on a 0-20 scale."""
+
+    weights = config.scoring.industrial_fit_weights
+    total_weight = sum(weights.values()) or 1.0
+    normalized_weight = {code: weight / total_weight for code, weight in weights.items()}
+
+    score = 0.0
+    for code, weight in normalized_weight.items():
+        cap = config.scoring.trait_caps.get(code, 1.0) or 1.0
+        normalized_trait = capped.get(code, 0.0) / cap
+        score += weight * normalized_trait
+    return score * 20.0
+
+
+def map_threshold(config: QuizConfig, fit_score: float) -> str:
+    """Map the fit score to a descriptive label using configured thresholds."""
+
+    thresholds = sorted(
+        config.scoring.thresholds,
+        key=lambda item: item.get("min_score", 0),
+        reverse=True,
+    )
+    for threshold in thresholds:
+        if fit_score >= float(threshold.get("min_score", 0)):
+            return str(threshold.get("label", ""))
+    return str(thresholds[-1].get("label", "")) if thresholds else ""
+
+
+def compose_feedback(config: QuizConfig, capped: Dict[str, float], label: str) -> Dict[str, Any]:
+    """Compose human-readable feedback details based on scores and tier."""
+
+    trait_codes = _ensure_trait_keys(config)
+    trait_caps = config.scoring.trait_caps
+    normalized = {
+        code: (capped.get(code, 0.0) / (trait_caps.get(code) or 1.0))
+        for code in trait_codes
+    }
+
+    sorted_traits = sorted(trait_codes, key=lambda code: normalized.get(code, 0.0), reverse=True)
+    trait_lookup = {trait.code: trait.name for trait in config.traits}
+    top_traits = [trait_lookup.get(code, code) for code in sorted_traits[:3]]
+
+    if label == "Strong Fit for Industrial Physics":
+        template_key = "strong"
+    elif label == "Potential Fit — Explore Further":
+        template_key = "potential"
+    else:
+        template_key = "explore"
+
+    overall_templates = config.feedback_templates.overall
+    overall_template = overall_templates.get(template_key, "")
+    overall_text = overall_template.replace("{{TOP_TRAITS}}", ", ".join(top_traits))
+
+    normalized_values = list(normalized.values()) or [0.0]
+    median_value = statistics.median(normalized_values)
+
+    snippets: List[str] = []
+    for code in sorted_traits:
+        value = normalized.get(code, 0.0)
+        snippet = config.feedback_templates.trait_snippets.get(code)
+        if snippet and value >= median_value:
+            snippets.append(snippet)
+    if not snippets:
+        for code in sorted_traits[:2]:
+            snippet = config.feedback_templates.trait_snippets.get(code)
+            if snippet:
+                snippets.append(snippet)
+
+    return {
+        "overall_text": overall_text,
+        "top_traits": top_traits,
+        "trait_snippets": snippets,
+        "next_steps": list(config.feedback_templates.next_steps),
+    }

--- a/quiz/utils.py
+++ b/quiz/utils.py
@@ -1,0 +1,23 @@
+"""Miscellaneous helpers shared across quiz modules."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .models import QuizConfig
+
+
+def trait_code_to_name(config: QuizConfig) -> Dict[str, str]:
+    """Create a mapping from trait code to display name."""
+
+    return {trait.code: trait.name for trait in config.traits}
+
+
+def normalize_scores(config: QuizConfig, scores: Dict[str, float]) -> Dict[str, float]:
+    """Normalize trait scores to the 0..1 range based on caps."""
+
+    normalized: Dict[str, float] = {}
+    for code, score in scores.items():
+        cap = config.scoring.trait_caps.get(code, 1.0) or 1.0
+        normalized[code] = min(score / cap, 1.0)
+    return normalized

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+jsonschema==4.23.0
+WTForms==3.1.2

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const progress = document.querySelector('.progress');
+  if (!progress) {
+    return;
+  }
+
+  const total = Number(progress.dataset.total || 0);
+  const fill = progress.querySelector('.progress-fill');
+  const label = progress.querySelector('.progress-label');
+  const form = document.querySelector('.quiz form');
+
+  if (!form || !fill || !label || !total) {
+    return;
+  }
+
+  const updateProgress = () => {
+    const answered = new Set();
+    const inputs = form.querySelectorAll('input[type="radio"]');
+    inputs.forEach((input) => {
+      if (input.checked) {
+        answered.add(input.name);
+      }
+    });
+
+    const completed = answered.size;
+    const percentage = Math.round((completed / total) * 100);
+    fill.style.width = `${percentage}%`;
+    label.textContent = `Question ${completed === 0 ? 1 : Math.min(completed + 1, total)} of ${total}`;
+  };
+
+  form.addEventListener('change', updateProgress);
+  updateProgress();
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,230 @@
+:root {
+  --primary: #1f6feb;
+  --accent: #f59e0b;
+  --background: #f8fafc;
+  --text: #1e293b;
+  --muted: #64748b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--background);
+  color: var(--text);
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+
+.site-header {
+  background: #0f172a;
+  color: #fff;
+}
+
+.site-title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.site-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--primary);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  margin-top: 1rem;
+}
+
+.btn.submit {
+  margin-top: 2rem;
+  width: 100%;
+  text-align: center;
+}
+
+.intro .lead {
+  font-size: 1.1rem;
+  margin-top: 1rem;
+}
+
+.meta {
+  color: var(--muted);
+}
+
+.flash-messages {
+  margin-bottom: 1.5rem;
+}
+
+.flash {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+}
+
+.flash.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.quiz .question {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.quiz .question h3 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.options {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.option input[type="radio"] {
+  accent-color: var(--primary);
+}
+
+.likert-scale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.likert-point {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.likert-point input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+.progress {
+  margin-bottom: 1.5rem;
+}
+
+.progress-track {
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--primary);
+  transition: width 0.3s ease;
+}
+
+.progress-label {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.result-summary {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  margin-bottom: 2rem;
+}
+
+.fit-label {
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.fit-score {
+  font-size: 2rem;
+  color: var(--primary);
+  margin-top: 0.5rem;
+}
+
+.top-traits {
+  color: var(--muted);
+}
+
+.trait-bars {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.trait-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.bar {
+  height: 12px;
+  background: #e2e8f0;
+  border-radius: 999px;
+}
+
+.fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+.feedback, .next-steps {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  margin-bottom: 1.5rem;
+}
+
+.feedback ul, .next-steps ol {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+@media (max-width: 600px) {
+  .likert-scale {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .likert-point {
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #e2e8f0;
+  }
+
+  .likert-point:last-child {
+    border-bottom: none;
+  }
+}

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -1,0 +1,36 @@
+{% macro choice_question(q, selected) %}
+<div class="question" id="{{ q.id }}">
+  <h3>{{ q.text }}</h3>
+  <div class="options">
+    {% for option in q.options %}
+      <label class="option">
+        <input type="radio" name="{{ q.id }}" value="{{ option.key }}" required {% if selected == option.key %}checked{% endif %}>
+        <span>{{ option.label }}</span>
+      </label>
+    {% endfor %}
+  </div>
+</div>
+{% endmacro %}
+
+{% macro likert_question(q, selected) %}
+<div class="question likert" id="{{ q.id }}">
+  <h3>{{ q.text }}</h3>
+  <div class="likert-scale">
+    {% for point in q.scale %}
+      <label class="likert-point">
+        <input type="radio" name="{{ q.id }}" value="{{ point }}" required {% if selected == point %}checked{% endif %}>
+        <div class="point-value">{{ point }}</div>
+        <div class="point-label">
+          {% if q.labels[point|string] is defined %}
+            {{ q.labels[point|string] }}
+          {% elif point == q.scale[0] and q.labels[q.scale[0]|string] is defined %}
+            {{ q.labels[q.scale[0]|string] }}
+          {% elif point == q.scale[-1] and q.labels[q.scale[-1]|string] is defined %}
+            {{ q.labels[q.scale[-1]|string] }}
+          {% endif %}
+        </div>
+      </label>
+    {% endfor %}
+  </div>
+</div>
+{% endmacro %}

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -21,12 +21,16 @@
         <input type="radio" name="{{ q.id }}" value="{{ point }}" required {% if selected == point %}checked{% endif %}>
         <div class="point-value">{{ point }}</div>
         <div class="point-label">
-          {% if q.labels[point|string] is defined %}
-            {{ q.labels[point|string] }}
-          {% elif point == q.scale[0] and q.labels[q.scale[0]|string] is defined %}
-            {{ q.labels[q.scale[0]|string] }}
-          {% elif point == q.scale[-1] and q.labels[q.scale[-1]|string] is defined %}
-            {{ q.labels[q.scale[-1]|string] }}
+          {% set labels = q.labels %}
+          {% set point_key = point ~ '' %}
+          {% set first_key = q.scale[0] ~ '' %}
+          {% set last_key = q.scale[-1] ~ '' %}
+          {% if labels.get(point_key) is not none %}
+            {{ labels.get(point_key) }}
+          {% elif point == q.scale[0] and labels.get(first_key) is not none %}
+            {{ labels.get(first_key) }}
+          {% elif point == q.scale[-1] and labels.get(last_key) is not none %}
+            {{ labels.get(last_key) }}
           {% endif %}
         </div>
       </label>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% set page_title = 'Industrial Physics Quiz' %}
+  {% if title is defined and title %}
+    {% set page_title = title %}
+  {% elif config is defined and config.title %}
+    {% set page_title = config.title %}
+  {% endif %}
+  <title>{{ page_title }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="site-title"><a href="{{ url_for('index') }}">Industrial Physics Quiz</a></h1>
+    </div>
+  </header>
+  <main class="container">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="flash-messages">
+          {% for category, message in messages %}
+            <div class="flash {{ category }}">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </main>
+  <script src="{{ url_for('static', filename='app.js') }}" defer></script>
+</body>
+</html>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<section class="error">
+  <h2>Something went wrong</h2>
+  <p>{{ message }}</p>
+  <a class="btn" href="{{ url_for('index') }}">Back to start</a>
+</section>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<section class="intro">
+  <h2>{{ config.title }}</h2>
+  {% if config.ui.length_minutes %}
+    <p class="meta">Estimated time: {{ config.ui.length_minutes }} minutes</p>
+  {% endif %}
+  <p class="lead">Assess how your interests and strengths align with industrial and applied physics work.</p>
+  <a class="btn" href="{{ url_for('quiz_view') }}">Start the quiz</a>
+</section>
+{% endblock %}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% import '_components.html' as components %}
+
+{% block content %}
+<section class="quiz">
+  <h2>{{ config.title }}</h2>
+  <form method="post">
+    {% if config.ui.progress_bar %}
+      <div class="progress" data-total="{{ progress.total_questions }}">
+        <div class="progress-track">
+          <div class="progress-fill" style="width: 0%"></div>
+        </div>
+        <div class="progress-label">Question 1 of {{ progress.total_questions }}</div>
+      </div>
+    {% endif %}
+
+    {% for question in questions %}
+      {% set selected = None %}
+      {% if previous_answers %}
+        {% set selected = previous_answers.get(question.id) %}
+      {% endif %}
+      {% if question.type in ['single_choice', 'forced_choice'] %}
+        {{ components.choice_question(question, selected|string if selected is not none else none) }}
+      {% elif question.type == 'likert' %}
+        {{ components.likert_question(question, selected|int if selected is not none else none) }}
+      {% endif %}
+    {% endfor %}
+
+    <button type="submit" class="btn submit">See my results</button>
+  </form>
+</section>
+{% endblock %}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -20,7 +20,7 @@
         {% set selected = previous_answers.get(question.id) %}
       {% endif %}
       {% if question.type in ['single_choice', 'forced_choice'] %}
-        {{ components.choice_question(question, selected|string if selected is not none else none) }}
+        {{ components.choice_question(question, selected if selected is not none else none) }}
       {% elif question.type == 'likert' %}
         {{ components.likert_question(question, selected|int if selected is not none else none) }}
       {% endif %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<section class="result">
+  <h2>Your Industrial Physics fit</h2>
+  <div class="result-summary">
+    <div class="fit-label">{{ label }}</div>
+    <div class="fit-score">{{ fit_score }} / 20</div>
+    <p class="overall">{{ feedback.overall_text }}</p>
+    {% if feedback.top_traits %}
+      <p class="top-traits"><strong>Top strengths:</strong> {{ feedback.top_traits | join(', ') }}</p>
+    {% endif %}
+  </div>
+
+  <div class="trait-bars">
+    {% for trait in traits %}
+      <div class="trait">
+        <div class="trait-header">
+          <span class="trait-name">{{ trait.name }}</span>
+          <span class="trait-score">{{ '%.1f'|format(trait.score) }}</span>
+        </div>
+        <div class="bar">
+          <div class="fill" style="width: {{ (trait.normalized * 100)|round(1) }}%"></div>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+
+  <section class="feedback">
+    <h3>Highlights</h3>
+    <ul>
+      {% for snippet in feedback.trait_snippets %}
+        <li>{{ snippet }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  <section class="next-steps">
+    <h3>Next steps to explore</h3>
+    <ol>
+      {% for step in feedback.next_steps %}
+        <li>{{ step }}</li>
+      {% endfor %}
+    </ol>
+  </section>
+
+  <a class="btn" href="{{ url_for('quiz_view') }}">Retake the quiz</a>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a Flask application that loads the quiz schema, renders routes, and persists answers in the session
- add quiz domain modules for models, validation, scoring, rendering helpers, and supporting utilities
- create templates, styling, scripts, and documentation to deliver the full quiz and results experience

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e6705baf6c8325bb64e49e2a778697